### PR TITLE
Support all instances of Reskillable requirements

### DIFF
--- a/src/main/java/net/tiffit/progressiveboxes/support/ReskillableType.java
+++ b/src/main/java/net/tiffit/progressiveboxes/support/ReskillableType.java
@@ -3,6 +3,7 @@ package net.tiffit.progressiveboxes.support;
 import codersafterdark.reskillable.api.ReskillableAPI;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
+import codersafterdark.reskillable.api.requirement.Requirement;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.text.TextFormatting;
 import net.tiffit.progressiveboxes.data.req.ReqType;
@@ -22,12 +23,14 @@ public class ReskillableType implements ReqType {
 	@Override
 	public boolean meetsReq(EntityPlayerMP p, String value) {
 		PlayerData data = PlayerDataHandler.get(p);
-		return data.requirementAchieved(ReskillableAPI.getInstance().getRequirementRegistry().getRequirement(value));
+		Requirement requirement = ReskillableAPI.getInstance().getRequirementRegistry().getRequirement(value);
+		return requirement != null && data.requirementAchieved(requirement);
 	}
 
 	@Override
 	public String localizeValue(String value) {
-		return "Requires: " + String.format(ReskillableAPI.getInstance().getRequirementRegistry().getRequirement(value).internalToolTip(), TextFormatting.RESET);
+		Requirement requirement = ReskillableAPI.getInstance().getRequirementRegistry().getRequirement(value);
+		return requirement == null ? "Error" : "Requires: " + String.format(requirement.internalToolTip(), TextFormatting.RESET);
 	}
 
 }

--- a/src/main/java/net/tiffit/progressiveboxes/support/ReskillableType.java
+++ b/src/main/java/net/tiffit/progressiveboxes/support/ReskillableType.java
@@ -1,9 +1,10 @@
 package net.tiffit.progressiveboxes.support;
 
+import codersafterdark.reskillable.api.ReskillableAPI;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
-import codersafterdark.reskillable.api.data.PlayerSkillInfo;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.text.TextFormatting;
 import net.tiffit.progressiveboxes.data.req.ReqType;
 
 public class ReskillableType implements ReqType {
@@ -21,22 +22,12 @@ public class ReskillableType implements ReqType {
 	@Override
 	public boolean meetsReq(EntityPlayerMP p, String value) {
 		PlayerData data = PlayerDataHandler.get(p);
-		String[] keyval = value.split(":");
-		String name = keyval[0];
-		int level = Integer.valueOf(keyval[1]);
-		for(PlayerSkillInfo info : data.getAllSkillInfo()){
-			if(info.skill.getName().equalsIgnoreCase(name)){
-				return info.getLevel() >= level;
-			}
-		}
-		return false;
+		return data.requirementAchieved(ReskillableAPI.getInstance().getRequirementRegistry().getRequirement(value));
 	}
 
 	@Override
 	public String localizeValue(String value) {
-		String[] spl = value.split(":");
-		if(spl.length < 2)return "Error";
-		return "Requires &c" + spl[0] + " Level " + spl[1] + "";
+		return "Requires: " + String.format(ReskillableAPI.getInstance().getRequirementRegistry().getRequirement(value).internalToolTip(), TextFormatting.RESET);
 	}
 
 }


### PR DESCRIPTION
I have not bothered to test this yet, but this should add support for all Requirements for Reskillable. This includes any properly implemented ones such as Requirements from CompatSkills. The syntax however changes from "skill:level" to the reskillable syntax of "reskillable:skill|level".